### PR TITLE
chore: upgrate nextJS version to avoid vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "html2canvas-pro": "^1.5.11",
         "jspdf": "^3.0.3",
         "lucide-react": "^0.542.0",
-        "next": "^15.5.7",
+        "next": "15.5.9",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-hook-form": "^7.62.0",
@@ -2124,9 +2124,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.7.tgz",
-      "integrity": "sha512-4h6Y2NyEkIEN7Z8YxkA27pq6zTkS09bUSYC0xjd0NpwFxjnIKeZEeH591o5WECSmjpUhLn3H2QLJcDye3Uzcvg==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.9.tgz",
+      "integrity": "sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
@@ -9377,12 +9377,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.7.tgz",
-      "integrity": "sha512-+t2/0jIJ48kUpGKkdlhgkv+zPTEOoXyr60qXe68eB/pl3CMJaLeIGjzp5D6Oqt25hCBiBTt8wEeeAzfJvUKnPQ==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
+      "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.7",
+        "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "html2canvas-pro": "^1.5.11",
     "jspdf": "^3.0.3",
     "lucide-react": "^0.542.0",
-    "next": "^15.5.7",
+    "next": "15.5.9",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.62.0",


### PR DESCRIPTION
### TL;DR

Update Next.js from version 15.5.7 to 15.5.9

### What changed?

- Updated Next.js dependency from version 15.5.7 to 15.5.9 in both package.json and package-lock.json
- Updated the corresponding @next/env dependency from 15.5.7 to 15.5.9 in package-lock.json

### How to test?

1. Pull the changes and run `npm install`
2. Start the development server with `npm run dev`
3. Verify that the application runs correctly with the updated Next.js version
4. Test key functionality to ensure nothing was broken by the version update

### Why make this change?

This update brings in the latest bug fixes and improvements from the Next.js 15.5.x release line. Keeping dependencies up to date helps maintain security and ensures we benefit from the latest performance improvements and bug fixes.